### PR TITLE
Remove direct X11 references in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,6 @@ endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     find_package(SDL2 REQUIRED)
-    find_package(X11 REQUIRED)
 
     add_compile_definitions("RT64_SDL_WINDOW_VULKAN")
 
@@ -327,14 +326,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     message(STATUS "SDL2_INCLUDE_DIRS = ${SDL2_INCLUDE_DIRS}")
 
     target_include_directories(MarioKart64Recompiled PRIVATE ${SDL2_INCLUDE_DIRS})
-
-    message(STATUS "X11_FOUND = ${X11_FOUND}")
-    message(STATUS "X11_Xrandr_FOUND = ${X11_Xrandr_FOUND}")
-    message(STATUS "X11_INCLUDE_DIR = ${X11_INCLUDE_DIR}")
-    message(STATUS "X11_LIBRARIES = ${X11_LIBRARIES}")
-
-    target_include_directories(MarioKart64Recompiled PRIVATE ${X11_INCLUDE_DIR} ${X11_Xrandr_INCLUDE_PATH})
-    target_link_libraries(MarioKart64Recompiled PRIVATE ${X11_LIBRARIES} ${X11_Xrandr_LIB})
 
     find_package(Freetype REQUIRED)
 


### PR DESCRIPTION
As in other recomps, X11 aren't really used for anything directly: SDL2 abstracts the windowing system to be used, as intended.
So removing these direct references to legacy X11 allows the recomp to build on Wayland-only GNU/Linux systems.